### PR TITLE
ARTEMIS-1868 Openwire doesn't add delivery count in client ack mode

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
@@ -16,6 +16,13 @@
  */
 package org.apache.activemq.artemis.core.protocol.openwire;
 
+import javax.jms.IllegalStateException;
+import javax.jms.InvalidClientIDException;
+import javax.jms.InvalidDestinationException;
+import javax.jms.JMSSecurityException;
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,14 +34,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
-
-import javax.jms.IllegalStateException;
-import javax.jms.InvalidClientIDException;
-import javax.jms.InvalidDestinationException;
-import javax.jms.JMSSecurityException;
-import javax.transaction.xa.XAException;
-import javax.transaction.xa.XAResource;
-import javax.transaction.xa.Xid;
 
 import org.apache.activemq.advisory.AdvisorySupport;
 import org.apache.activemq.artemis.api.core.ActiveMQAddressExistsException;
@@ -1294,7 +1293,8 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
                   referenceIterator.remove();
                   ref.incrementDeliveryCount();
                   consumer.backToDelivering(ref);
-                  session.addRolledback(ref.getMessageID());
+                  final AMQConsumer amqConsumer = (AMQConsumer) consumer.getProtocolData();
+                  amqConsumer.addRolledback(ref);
                }
             }
          }


### PR DESCRIPTION
It is just a proposal to reduce the cost of each call on the hot path of send when 
no rollbacks have ever happened.
It is taking in account the uses of a data structure that will shrink when the rolledback
messages will be removed, but at the expence of slower operations.
It is not taking into accout a couple of things:

- MessageReference semantic of equals and hashCode 
- MessageReference cost of equals and hashCode (when paging is involved, in particular)
- Leaks of MessageReference instances (ServerConsumerImpl should have same problem)
- no warning logs to check for too many rollback instances
- the existing test doesn't seem to trigger the added behaviour yet 